### PR TITLE
TRAC-6525 build FCL wrapper to return Execution template string

### DIFF
--- a/FCLWrapper.cpp
+++ b/FCLWrapper.cpp
@@ -9,6 +9,7 @@
 #include "CommonIncludes.h"
 #include "LDAL_Wrapper.h"
 #include <string>
+#include "Formula.h"
 //#include "LogJsonParser.h"
 //#include "OTPParser.h"
 
@@ -69,4 +70,10 @@ std::string  FCLWrapper::GetTDPResultV2(const char *defFilePath ,const char *que
 std::string  FCLWrapper::GetCommonJSON(const char *defFilePath ,const char *query,const char *json ) {
     LDAL_Wrapper ldalWrapper;
     return  ldalWrapper.GetCommonJSONResult(defFilePath,query,json);
+}
+
+std::string FCLWrapper::GetExecutionTemplateJSONString(const char *defFilePath, const char *query)
+{
+    Formula fm;
+    return fm.BuildExecutionTemplateJSONString(defFilePath, query);
 }

--- a/FCLWrapper.h
+++ b/FCLWrapper.h
@@ -19,6 +19,7 @@ public:
     std::string  GetTDPResultV2(const char *defFilePath ,const char *query,const char *json);
     std::string  GetOTPResultV2(const char *defFilePath ,const char *query,const char *json);
     std::string  GetCommonJSON(const char *defFilePath ,const char *query,const char *json);
+    std::string GetExecutionTemplateJSONString(const char *defFilePath, const char *query);
 };
 
 #endif //CODE_FCLWRAPPER_H

--- a/FCLWrapper_wrap.cxx
+++ b/FCLWrapper_wrap.cxx
@@ -896,6 +896,33 @@ _gostring_ _wrap_FCLWrapper_GetCommonJSON_FCLlib_1ee54ad49562e6e8(FCLWrapper *_s
 }
 
 
+_gostring_ _wrap_FCLWrapper_GetExecutionTemplateJSONString_FCLlib_1ee54ad49562e6e8(FCLWrapper *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2) {
+  FCLWrapper *arg1 = (FCLWrapper *) 0 ;
+  char *arg2 = (char *) 0 ;
+  char *arg3 = (char *) 0 ;
+  std::string result;
+  _gostring_ _swig_go_result;
+  
+  arg1 = *(FCLWrapper **)&_swig_go_0; 
+  
+  arg2 = (char *)malloc(_swig_go_1.n + 1);
+  memcpy(arg2, _swig_go_1.p, _swig_go_1.n);
+  arg2[_swig_go_1.n] = '\0';
+  
+  
+  arg3 = (char *)malloc(_swig_go_2.n + 1);
+  memcpy(arg3, _swig_go_2.p, _swig_go_2.n);
+  arg3[_swig_go_2.n] = '\0';
+  
+  
+  result = (arg1)->GetExecutionTemplateJSONString((char const *)arg2,(char const *)arg3);
+  _swig_go_result = Swig_AllocateString((&result)->data(), (&result)->length()); 
+  free(arg2); 
+  free(arg3); 
+  return _swig_go_result;
+}
+
+
 FCLWrapper *_wrap_new_FCLWrapper_FCLlib_1ee54ad49562e6e8() {
   FCLWrapper *result = 0 ;
   FCLWrapper *_swig_go_result;

--- a/FCLlib.go
+++ b/FCLlib.go
@@ -66,6 +66,9 @@ typedef _gostring_ swig_type_35;
 typedef _gostring_ swig_type_36;
 typedef _gostring_ swig_type_37;
 typedef _gostring_ swig_type_38;
+typedef _gostring_ swig_type_39;
+typedef _gostring_ swig_type_40;
+typedef _gostring_ swig_type_41;
 extern void _wrap_Swig_free_FCLlib_1ee54ad49562e6e8(uintptr_t arg1);
 extern uintptr_t _wrap_Swig_malloc_FCLlib_1ee54ad49562e6e8(swig_intgo arg1);
 extern uintptr_t _wrap_new_StringVector__SWIG_0_FCLlib_1ee54ad49562e6e8(void);
@@ -102,6 +105,7 @@ extern swig_type_23 _wrap_FCLWrapper_GetLogLDALResultV2_FCLlib_1ee54ad49562e6e8(
 extern swig_type_27 _wrap_FCLWrapper_GetTDPResultV2_FCLlib_1ee54ad49562e6e8(uintptr_t arg1, swig_type_28 arg2, swig_type_29 arg3, swig_type_30 arg4);
 extern swig_type_31 _wrap_FCLWrapper_GetOTPResultV2_FCLlib_1ee54ad49562e6e8(uintptr_t arg1, swig_type_32 arg2, swig_type_33 arg3, swig_type_34 arg4);
 extern swig_type_35 _wrap_FCLWrapper_GetCommonJSON_FCLlib_1ee54ad49562e6e8(uintptr_t arg1, swig_type_36 arg2, swig_type_37 arg3, swig_type_38 arg4);
+extern swig_type_39 _wrap_FCLWrapper_GetExecutionTemplateJSONString_FCLlib_1ee54ad49562e6e8(uintptr_t arg1, swig_type_40 arg2, swig_type_41 arg3);
 extern uintptr_t _wrap_new_FCLWrapper_FCLlib_1ee54ad49562e6e8(void);
 extern void _wrap_delete_FCLWrapper_FCLlib_1ee54ad49562e6e8(uintptr_t arg1);
 #undef intgo
@@ -569,6 +573,24 @@ func (arg1 SwigcptrFCLWrapper) GetCommonJSON(arg2 string, arg3 string, arg4 stri
 	return swig_r_1
 }
 
+func (arg1 SwigcptrFCLWrapper) GetExecutionTemplateJSONString(arg2 string, arg3 string) (_swig_ret string) {
+	var swig_r string
+	_swig_i_0 := arg1
+	_swig_i_1 := arg2
+	_swig_i_2 := arg3
+	swig_r_p := C._wrap_FCLWrapper_GetExecutionTemplateJSONString_FCLlib_1ee54ad49562e6e8(C.uintptr_t(_swig_i_0), *(*C.swig_type_40)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_41)(unsafe.Pointer(&_swig_i_2)))
+	swig_r = *(*string)(unsafe.Pointer(&swig_r_p))
+	if Swig_escape_always_false {
+		Swig_escape_val = arg2
+	}
+	if Swig_escape_always_false {
+		Swig_escape_val = arg3
+	}
+	var swig_r_1 string
+ swig_r_1 = swigCopyString(swig_r) 
+	return swig_r_1
+}
+
 func NewFCLWrapper() (_swig_ret FCLWrapper) {
 	var swig_r FCLWrapper
 	swig_r = (FCLWrapper)(SwigcptrFCLWrapper(C._wrap_new_FCLWrapper_FCLlib_1ee54ad49562e6e8()))
@@ -593,6 +615,7 @@ type FCLWrapper interface {
 	GetTDPResultV2(arg2 string, arg3 string, arg4 string) (_swig_ret string)
 	GetOTPResultV2(arg2 string, arg3 string, arg4 string) (_swig_ret string)
 	GetCommonJSON(arg2 string, arg3 string, arg4 string) (_swig_ret string)
+	GetExecutionTemplateJSONString(arg2 string, arg3 string) (_swig_ret string)
 }
 
 


### PR DESCRIPTION
TRAC-6525 build FCL wrapper to return Execution template string

- build a wrapper using a swig
- add GetExecutionTemplateJSONString() method to wrapper interface